### PR TITLE
Speed up CRC computation

### DIFF
--- a/src/silabs_rps/rps_crc/__init__.py
+++ b/src/silabs_rps/rps_crc/__init__.py
@@ -11,54 +11,25 @@ sections of the MSLA applicable to Source Code.
 *******************************************************************************
 """
 
-from ctypes import c_uint32
+# For reference:
+#     width=32 poly=0xd95eaae5 init=0 refin=true refout=true xorout=0
+def create_table() -> list[int]:
+    crc_table = [0] * 256
+    for b in range(256):
+        register = b
+        for _ in range(8):
+            lsb = register & 1
+            register >>= 1
+            if lsb:
+                # Reflected polynomial: 0xd95eaae5
+                register ^= 0xA7557A9B
+        crc_table[b] = register
+    return crc_table
 
 
-POLYNOMIAL = c_uint32(0xD95EAAE5)
-MSB_MASK   = c_uint32(0x80000000)
-CRC_MASK   = c_uint32(0xFFFFFFFF)
-
-def crc32(data : bytes) -> int:
-    """ Calculate the 32 bit CRC of the given data. Proprietary algorithm. """
-
-    crc : c_uint32 = c_uint32(0x0)
-
-    for _ in range (0, 32):
-        if (crc.value & 0x01):
-            crc = c_uint32(((crc.value ^ POLYNOMIAL.value) >> 1) | MSB_MASK.value)
-        else:
-            crc = c_uint32(crc.value >> 1)
-
-    for byte in data:
-        c = _reflect(c_uint32(byte), 8)
-
-        for i in range(0, 8):
-            bit : int = crc.value & MSB_MASK.value
-            crc = c_uint32(
-                c_uint32(crc.value << 1).value | ((c.value >> (7 - i)) & 0x01)
-            )
-            if bit:
-                crc = c_uint32(crc.value ^ POLYNOMIAL.value)
-
-        crc = c_uint32(crc.value & CRC_MASK.value)
-
-    for _ in range(0, 32):
-        bit : int = crc.value & MSB_MASK.value
-        crc = c_uint32(crc.value << 1)
-        if bit:
-            crc = c_uint32(crc.value ^ POLYNOMIAL.value)
-
-    crc = _reflect(crc, 32)
-
-    return c_uint32(crc.value & CRC_MASK.value).value 
-
-
-def _reflect(number : c_uint32, width : int) -> c_uint32:
-    """ Reflect the bits of the given number. """
-    ret : c_uint32 = c_uint32(number.value & 0x01)
-
-    for _ in range(1, width):
-        number = c_uint32(number.value >> 1)
-        ret = c_uint32((ret.value << 1) | (number.value & 0x01))
-
-    return ret
+def crc32(data: bytes) -> int:
+    crc_table = create_table()
+    register = 0
+    for b in data:
+        register = crc_table[(b ^ register) & 0xFF] ^ (register >> 8)
+    return register

--- a/tests/test_rps_crc.py
+++ b/tests/test_rps_crc.py
@@ -14,9 +14,7 @@ sections of the MSLA applicable to Source Code.
 import unittest
 import os
 
-from ctypes import c_uint32
-
-from src.silabs_rps.rps_crc import crc32, _reflect
+from src.silabs_rps.rps_crc import crc32
 
 TEST_FILE_DIR = "tests/testfiles/crc/"
 
@@ -27,18 +25,6 @@ class TestHelpers(unittest.TestCase):
         with open(os.path.join(TEST_FILE_DIR, "app-no-crc.rps"), "rb") as f:
             data = f.read()
         self.assertEqual(crc32(data), expected_crc)
-
-    def test_reflect_helper(self):
-        self.assertEqual(_reflect(c_uint32(0x01), 8).value, c_uint32(0x80).value)
-        self.assertEqual(_reflect(c_uint32(0x80), 8).value, c_uint32(0x01).value)
-        self.assertEqual(_reflect(c_uint32(0x00), 8).value, c_uint32(0x00).value)
-        self.assertEqual(_reflect(c_uint32(0xFF), 8).value, c_uint32(0xFF).value)
-
-        self.assertEqual(_reflect(c_uint32(0x00000001), 32).value, c_uint32(0x80000000).value)
-        self.assertEqual(_reflect(c_uint32(0x80000000), 32).value, c_uint32(0x00000001).value)
-        self.assertEqual(_reflect(c_uint32(0x00000000), 32).value, c_uint32(0x00000000).value)
-        self.assertEqual(_reflect(c_uint32(0xFFFFFFFF), 32).value, c_uint32(0xFFFFFFFF).value)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Rather than reverting every byte, it is faster to apply the reverted polynomial algorithm[1]. With that change, I able to generate .rps file 14x time faster (0.1s vs 1.4s).

Note in my previous implementation, I tries to compute the CRC table offline. It appears it is faster to compute the table on runtime rather than loading the Python array.

I have check the resulting binaries are exactly the same.

[1]: https://zlib.net/crc_v3.txt (section 11.)